### PR TITLE
Ability to install a gem on multiple rubies

### DIFF
--- a/manifests/define/gem.pp
+++ b/manifests/define/gem.pp
@@ -1,15 +1,17 @@
 # Compliments of Toni Leino (Frodotus)
 # # https://github.com/Frodotus/puppet-rvm/commit/17d854f20f0d49185938f84c4108823e9212c02a
 define rvm::define::gem(
-  $ensure = 'present',
   $ruby_version,
-  $gemset = '',
-  $gem_version = '',
+  $gem_name         = $name,
+  $ensure           = 'present',
+  $gemset           = '',
+  $gem_version      = '',
   $allow_prerelease = false
-) {  
+) {
+
   ## Set sensible defaults for Exec resource
   Exec {
-    path    => '/usr/local/rvm/bin:/bin:/sbin:/usr/bin:/usr/sbin',
+    path => '/usr/local/rvm/bin:/bin:/sbin:/usr/bin:/usr/sbin',
   }
 
   # Local Parameters
@@ -32,31 +34,33 @@ define rvm::define::gem(
   # Setup proper install/uninstall commands based on gem version.
   if $gem_version == '' {
     $gem = {
-      'install'   => "rvm ${rubyset_version} do gem install ${name} ${prerelease} --no-ri --no-rdoc",
-      'uninstall' => "rvm ${rubyset_version} do gem uninstall ${name}",
-      'lookup'    => "rvm ${rubyset_version} do gem list | grep ${name}",
+      'install'   => "rvm ${rubyset_version} do gem install ${gem_name} ${prerelease} --no-ri --no-rdoc",
+      'uninstall' => "rvm ${rubyset_version} do gem uninstall ${gem_name}",
+      'lookup'    => "rvm ${rubyset_version} do gem list | grep ${gem_name}",
     }
-  } else {
+  }
+  else {
     $gem = {
-      'install'   => "rvm ${rubyset_version} do gem install ${name} ${prerelease} -v ${gem_version} --no-ri --no-rdoc",
-      'uninstall' => "rvm ${rubyset_version} do gem uninstall ${name} -v ${gem_version}",
-      'lookup'    => "rvm ${rubyset_version} do gem list | grep ${name} | grep ${gem_version}",
+      'install'   => "rvm ${rubyset_version} do gem install ${gem_name} ${prerelease} -v ${gem_version} --no-ri --no-rdoc",
+      'uninstall' => "rvm ${rubyset_version} do gem uninstall ${gem_name} -v ${gem_version}",
+      'lookup'    => "rvm ${rubyset_version} do gem list | grep ${gem_name} | grep ${gem_version}",
     }
   }
 
-  
+
   ## Begin Logic
   if $ensure == 'present' {
-    exec { "rvm-gem-install-${name}-${ruby_version}":
+    exec { "rvm-gem-install-${gem_name}-${gem_version}-${ruby_version}":
       command => $gem['install'],
       unless  => $gem['lookup'],
       require => [Class['rvm'], Exec[$rvm_depency]],
     }
-  } elsif $ensure == 'absent' {
-    exec { "rvm-gem-uninstall-${name}-${version}":
+  }
+  elsif $ensure == 'absent' {
+    exec { "rvm-gem-uninstall-${gem_name}-${gem_version}-${ruby_version}":
       command => $gem['uninstall'],
       onlyif  => $gem['lookup'],
       require => [Class['rvm'], Exec[$rvm_depency]],
-    }    
+    }
   }
 }


### PR DESCRIPTION
Prior to this commit, a user would not be able to use `rvm::define::gem`
to install a gem with the same name (e.g. 'bundler') across multiple
rubies, as the resource would all have the same namevar (bundler) albeit
different parameters (ruby_version, for example).

This commit adds an additional parameter to the defined type: gem_name.
It defaults to `$name` (to be backwards compatible), but otherwise
allows the user to give an arbitrary namevar to the resource and pass
in the gem name as a parameter.